### PR TITLE
0.0.6 for OCP 4.9 compatiblity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL name="Yugabyte Platform Operator" \
       maintainer="oss-maintainers@yugabyte.com" \
       vendor="Yugabyte Inc" \
       release="1" \
-      version="0.0.4" \
+      version="0.0.6" \
       summary="Container image for Yugabyte Platform operator" \
       description="Operator for Yugabyte Platform makes it easy to deploy and upgrade Yugabyte platform on kubernetes environment"
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 0.0.4
+VERSION ?= 0.0.6
 # Bundle channels
 CHANNELS ?= alpha
 DEFAULT_CHANNEL ?= alpha

--- a/bundle/manifests/yugabyte-platform-operator-metrics-reader_rbac.authorization.k8s.io_v1beta1_clusterrole.yaml
+++ b/bundle/manifests/yugabyte-platform-operator-metrics-reader_rbac.authorization.k8s.io_v1beta1_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null

--- a/bundle/manifests/yugabyte-platform-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/yugabyte-platform-operator.clusterserviceversion.yaml
@@ -317,4 +317,6 @@ spec:
     name: Yugabyte Inc
   version: 0.0.6
   # manually added line
-  replaces: yugabyte-platform-operator.v0.0.5
+  # https://v0-18-z.olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/
+  skips:
+  - yugabyte-platform-operator.v0.0.5

--- a/bundle/manifests/yugabyte-platform-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/yugabyte-platform-operator.clusterserviceversion.yaml
@@ -86,13 +86,13 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Database
     certified: "true"
-    containerImage: registry.connect.redhat.com/yugabytedb/yugabyte-platform-operator:0.0.4
+    containerImage: registry.connect.redhat.com/yugabytedb/yugabyte-platform-operator:0.0.6
     description: Operator for Yugabyte Platform makes it easy to deploy and upgrade Yugabyte Platform on OpenShift environments.
     operators.operatorframework.io/builder: operator-sdk-v1.0.1
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/yugabyte/yugabyte-platform-operator
     support: YugabyteDB
-  name: yugabyte-platform-operator.v0.0.4
+  name: yugabyte-platform-operator.v0.0.6
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -267,7 +267,7 @@ spec:
                 - --metrics-addr=127.0.0.1:8080
                 - --enable-leader-election
                 - --leader-election-id=yugabyte-platform-operator
-                image: registry.connect.redhat.com/yugabytedb/yugabyte-platform-operator:0.0.4
+                image: registry.connect.redhat.com/yugabytedb/yugabyte-platform-operator:0.0.6
                 name: manager
                 resources: {}
               terminationGracePeriodSeconds: 10
@@ -315,6 +315,6 @@ spec:
   maturity: alpha
   provider:
     name: Yugabyte Inc
-  version: 0.0.4
+  version: 0.0.6
   # manually added line
-  replaces: yugabyte-platform-operator.v0.0.3
+  replaces: yugabyte-platform-operator.v0.0.5

--- a/bundle/manifests/yugabyte.com_ybplatforms.yaml
+++ b/bundle/manifests/yugabyte.com_ybplatforms.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -11,34 +11,33 @@ spec:
     plural: ybplatforms
     singular: ybplatform
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: YBPlatform is the Schema for the ybplatforms API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Spec defines the desired state of YBPlatform
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-        status:
-          description: Status defines the observed state of YBPlatform
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: YBPlatform is the Schema for the ybplatforms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of YBPlatform
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of YBPlatform
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/yugabyte.com_ybplatforms.yaml
+++ b/config/crd/bases/yugabyte.com_ybplatforms.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ybplatforms.yugabyte.com
@@ -15,31 +15,30 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-  validation:
-    openAPIV3Schema:
-      description: YBPlatform is the Schema for the ybplatforms API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Spec defines the desired state of YBPlatform
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-        status:
-          description: Status defines the observed state of YBPlatform
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  version: v1alpha1
-  subresources:
-    status: {}
+    schema:
+      openAPIV3Schema:
+        description: YBPlatform is the Schema for the ybplatforms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of YBPlatform
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of YBPlatform
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    subresources:
+      status: {}

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: registry.connect.redhat.com/yugabytedb/yugabyte-platform-operator
-  newTag: 0.0.4
+  newTag: 0.0.6


### PR DESCRIPTION
### Summary

The yugabyte platform version is the same as the previous version of the operator had. The operator v0.0.6 have modification to make the operator compatible with OCP 4.9.